### PR TITLE
Fix tailwind, again?

### DIFF
--- a/.github/workflows/ghPages.yml
+++ b/.github/workflows/ghPages.yml
@@ -26,7 +26,7 @@ jobs:
         run: cd tailwind && npm install tailwindcss@1.9.6 --no-save
 
       - name: Build 🔧
-        run: cd tailwind && npx tailwindcss-cli build tailwindStyles.css -c tailwind.config.prod.js | npx clean-css-cli > tailwind.css
+        run: cd tailwind && npx tailwindcss build tailwindStyles.css -c tailwind.config.prod.js | npx clean-css-cli > tailwind.css
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1

--- a/tailwind/README.md
+++ b/tailwind/README.md
@@ -5,13 +5,13 @@
 
 ## Generate developer Tailwindcss build:
 
-`npx tailwindcss-cli build tailwindStyles.css > tailwind.css`
+`npx tailwindcss build tailwindStyles.css > tailwind.css`
 
 This will produce all classes used by Tailwindcss.
 
 
 ## Generate production Tailwindcss build:
 
-`npx tailwindcss-cli build tailwindStyles.css -c tailwind.config.prod.js | npx clean-css-cli > tailwind.css`
+`npx tailwindcss build tailwindStyles.css -c tailwind.config.prod.js | npx clean-css-cli > tailwind.css`
 
 This will produce classes only used in code(files are specified in `./tailwind.config.prod.js`) and minify the resulting css.


### PR DESCRIPTION
Tak nakoniec ešte raz.

`tailwindcss-cli` vyzerá, že používa tailwind 2, zatiaľ čo starý `tailwindcss` používa nainštalovanú verziu :shrug: 

Je ale možné, že budeme musieť aj iné dependencies locknúť na CI, len to neviem u seba overiť.