### PR TITLE
Add cancelled event indicator

### DIFF
--- a/terminy.html
+++ b/terminy.html
@@ -236,11 +236,11 @@
           </div>
 
           <h2 class="text-2xl -mt-1 flex items-center md:mr-5">
-            {{#volatile}}
+            {{^cancelled}}{{#volatile}}
               <div class="tooltip relative">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#EC8B14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-alert-triangle w-8 mr-1 flex-shrink-0"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
               </div>
-            {{/volatile}}
+            {{/volatile}}{{/cancelled}}
             {{#cancelled}}
               <span class="text-white text-sm mr-2 rounded bg-red-700 px-2 font-bold tracking-wide">Zrušené</span>
             {{/cancelled}}

--- a/terminy.html
+++ b/terminy.html
@@ -241,7 +241,10 @@
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#EC8B14" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-alert-triangle w-8 mr-1 flex-shrink-0"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
               </div>
             {{/volatile}}
-            <span>{{ name }}</span>
+            {{#cancelled}}
+              <span class="text-white text-sm mr-2 rounded bg-red-700 px-2 font-bold tracking-wide">Zrušené</span>
+            {{/cancelled}}
+            <span class="{{#cancelled}}line-through{{/cancelled}}">{{ name }}</span>
           </h2>
 
           {{#info}}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11409143/103296362-3b439780-49f6-11eb-9560-e2c5f927670d.png)

Len si nie som istý, v akom rode to má byť :thinking: zrušené/ý/á?
A tiež by možno bolo rozumné nezobrazovať volatile, ak je event zrušený?


Closes #69 