### PR TITLE
Ignore tailwind output file in linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tailwind/build.css linguist-generated


### PR DESCRIPTION
Toto zmení to, že aktuálne frontend je 98% CSS. Ako bonus sa diff build.css nebude ani zobrazovať pri commitoch.

See https://github.com/github/linguist#using-gitattributes