### PR TITLE
Update cached CSS on rebuild

### DIFF
--- a/.github/workflows/ghPages.yml
+++ b/.github/workflows/ghPages.yml
@@ -32,7 +32,9 @@ jobs:
           npx tailwindcss build tailwind.temp.css -c tailwind.config.prod.js | npx clean-css-cli > build.css
 
       - name: Remove dev css links
-        run: sed -i 's/<link href="tailwind\/custom.css" rel="stylesheet">//g' *.html
+        run: |
+          sed -i 's|<link href="tailwind/custom.css" rel="stylesheet">||g' *.html
+          sed -i "s|tailwind/build.css|tailwind/build.css?v=$(git log --format="%h" -n 1)|g" *.html
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1


### PR DESCRIPTION
Browser môže mať zacacheované CSS, čo pri jeho zmene robí takéto zázraky:
![image](https://user-images.githubusercontent.com/11409143/104481800-7e8d3100-55c6-11eb-88b4-d8139f3f551e.png)

Na koniec CSS adresy pridáme ?v=commit_id, čím efektívne resetneme cache v prehliadači.