### PR TITLE
Override search

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,6 +84,39 @@ const close_modal = () => {
 	document.getElementById("filter-modal").style.display = "none"
 }
 
+const open_search = () => {
+	const anim = document.getElementById('search-modal').animate(
+		[{transform: "translateY(5rem)"}],
+		{ duration: 1000, fill: 'both', easing: 'ease' },
+	);
+	anim.addEventListener('finish', () => {
+		anim.commitStyles();
+		anim.cancel();
+	});
+	let search_input = document.getElementById('search-input');
+	search_input.focus();
+	search_input.value = localStorage.getItem('search');
+	render();
+	CALENDAR.refresh();
+}
+
+const close_search = () => {
+	const anim = document.getElementById('search-modal').animate(
+		[{transform: "translateY(0)"}],
+		{ duration: 1000, fill: 'both', easing: 'ease' },
+	);
+	anim.addEventListener('finish', () => {
+		anim.commitStyles();
+		anim.cancel();
+	});
+	let search_input = document.getElementById('search-input');
+	localStorage.setItem('search', search_input.value);
+	document.getElementById('mobile-search-input').value = "";
+	search_input.value = "";
+	render();
+	CALENDAR.refresh();
+}
+
 const sorting_key = (event) => {
 	if (event.date.end) {
 		return Math.min(
@@ -296,6 +329,11 @@ const render = () => {
 		return false
 	})
 
+	//filter search
+	visible_events = visible_events.filter(x => JSON.stringify(x).includes(document.getElementById('search-input').value))
+	//filter search mobile
+	visible_events = visible_events.filter(x => JSON.stringify(x).includes(document.getElementById('mobile-search-input').value))
+
 	visible_events.forEach((event, index) => {
 		event.id = index
 	})
@@ -461,10 +499,25 @@ document.querySelectorAll('.js-filter-checkbox').forEach((elem) => elem.onchange
 
 window.addEventListener("keydown", e => {
 	if(!e.isComposing && e.keyCode === 27){
-		close_modal()
+		close_modal();
+		close_search();
+	}
+	if (e.keyCode === 114 || ((e.ctrlKey || e.metaKey) && e.keyCode === 70)) { 
+		e.preventDefault();
+		open_search();
 	}
 })
 
+let search_timer = 0;
+document.querySelectorAll('[type=search]').forEach( parent => {
+	parent.addEventListener('input', e => {
+		clearTimeout(search_timer);
+		search_timer = setTimeout(() => {
+			render();
+			CALENDAR.refresh();
+		}, 300);
+	})
+})
 
 let last_scroll = document.getElementById('scroll').scrollTop
 document.getElementById('scroll').addEventListener('scroll', e => {

--- a/app.js
+++ b/app.js
@@ -87,7 +87,7 @@ const close_modal = () => {
 const open_search = () => {
 	const anim = document.getElementById('search-modal').animate(
 		[{transform: "translateY(5rem)"}],
-		{ duration: 1000, fill: 'both', easing: 'ease' },
+		{ duration: 200, fill: 'both', easing: 'ease' },
 	);
 	anim.addEventListener('finish', () => {
 		anim.commitStyles();
@@ -103,7 +103,7 @@ const open_search = () => {
 const close_search = () => {
 	const anim = document.getElementById('search-modal').animate(
 		[{transform: "translateY(0)"}],
-		{ duration: 1000, fill: 'both', easing: 'ease' },
+		{ duration: 200, fill: 'both', easing: 'ease' },
 	);
 	anim.addEventListener('finish', () => {
 		anim.commitStyles();

--- a/tailwind/build.css
+++ b/tailwind/build.css
@@ -577,6 +577,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   right: 0px;
 }
 
+.-top-20 {
+  top: -5rem;
+}
+
 .isolate {
   isolation: isolate;
 }
@@ -858,6 +862,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   height: 16rem;
 }
 
+.h-18 {
+  height: 4.5rem;
+}
+
 .h-6 {
   height: 1.5rem;
 }
@@ -932,6 +940,14 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .flex-1 {
   flex: 1 1 0%;
+}
+
+.flex-auto {
+  flex: 1 1 auto;
+}
+
+.flex-none {
+  flex: none;
 }
 
 .flex-shrink-0 {
@@ -1738,6 +1754,11 @@ Ensure the default browser behavior of the `hidden` attribute.
   border-radius: 0.375rem;
 }
 
+.rounded-b-lg {
+  border-bottom-right-radius: 0.5rem;
+  border-bottom-left-radius: 0.5rem;
+}
+
 .rounded-t {
   border-top-left-radius: 0.25rem;
   border-top-right-radius: 0.25rem;
@@ -1863,6 +1884,11 @@ Ensure the default browser behavior of the `hidden` attribute.
   border-color: rgb(237 242 247 / var(--tw-border-opacity));
 }
 
+.border-gray-400 {
+  --tw-border-opacity: 1;
+  border-color: rgb(203 213 224 / var(--tw-border-opacity));
+}
+
 .bg-blue-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(66 153 225 / var(--tw-bg-opacity));
@@ -1900,6 +1926,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 .bg-white {
   --tw-bg-opacity: 1;
   background-color: rgb(255 255 255 / var(--tw-bg-opacity));
+}
+
+.bg-transparent {
+  background-color: transparent;
 }
 
 .bg-orange-100 {
@@ -2132,6 +2162,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   padding-top: 1.5rem;
 }
 
+.pb-8 {
+  padding-bottom: 2rem;
+}
+
 .text-left {
   text-align: left;
 }
@@ -2218,6 +2252,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .font-bold {
   font-weight: 700;
+}
+
+.font-semibold {
+  font-weight: 600;
 }
 
 .uppercase {
@@ -2727,6 +2765,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   background-color: #cbd5e0;
 }
 
+input[type="search"]::-webkit-search-cancel-button {
+  display: none;
+}
+
 .hover\:border-gray-200:hover {
   --tw-border-opacity: 1;
   border-color: rgb(237 242 247 / var(--tw-border-opacity));
@@ -2745,6 +2787,11 @@ Ensure the default browser behavior of the `hidden` attribute.
 .hover\:bg-blue-600:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(49 130 206 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-blue-100:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(235 248 255 / var(--tw-bg-opacity));
 }
 
 .hover\:font-bold:hover {
@@ -2773,6 +2820,11 @@ Ensure the default browser behavior of the `hidden` attribute.
 .hover\:before\:text-center:hover::before {
   content: var(--tw-content);
   text-align: center;
+}
+
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
 }
 
 .hover\:focus\:text-center:focus:hover {

--- a/tailwind/tailwind.css
+++ b/tailwind/tailwind.css
@@ -9,3 +9,7 @@
   @apply w-10 h-6 rounded-full cursor-pointer relative mr-2;
   background-color: #cbd5e0;
 }
+
+input[type="search"]::-webkit-search-cancel-button {
+  display: none;
+}

--- a/terminy.html
+++ b/terminy.html
@@ -142,8 +142,16 @@
 
   <div class="fixed z-10 overflow-y-auto" id="filter-modal" style="display: none;">
     <div class="fixed min-h-screen w-screen bg-black/25 z-20" onclick="close_modal()"></div>
-    <div class="fixed left-0 right-0 bg-white max-w-xl mx-auto p-8 rounded-lg z-30 mt-5">
-      <h2 class="font-bold uppercase text-gray-700 text-sm mb-2">Typ školy</h2>
+    <div class="fixed left-0 right-0 bg-white max-w-xl mx-auto px-8 pb-8 rounded-lg z-30 mt-5">
+      <div class="flex items-center border-b border-gray-400">
+        <label for="search-input" id="mobile-search-label">
+          <svg width='24' height='24' viewBox='0 0 24 24' fill='none'><path d='M21 21L15 15M17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10Z' stroke='#06b6d4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/></svg>
+        </label>
+        <input class="h-18 appearance-none mx-4 font-semibold flex-auto bg-transparent focus:outline-none" aria-autocomplete="list" aria-labelledby="mobile-search-label" id="mobile-search-input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Hľadať udalosť" maxlength="64" type="search">
+        <button type="reset" title="Zmaže hľadanie" class="flex-none rounded-lg border border-blue-500 text-blue-500 font-bold px-3 py-2 hover:bg-blue-100 text-xs" onclick="close_search()">Zmaž</button>
+      </div>
+
+      <h2 class="font-bold uppercase text-gray-700 text-sm mt-6 mb-2">Ročníky</h2>
 
       <label class="flex select-none items-center my-1">
         <input class="js-filter-checkbox hidden" type="checkbox" data-filter="school" value="zs">
@@ -221,6 +229,13 @@
     </div>
   </div>
 
+  <div class="fixed left-0 right-0 bg-white max-w-xl mx-auto px-6 rounded-b-lg z-30 border border-gray-400 flex items-center -top-20" id="search-modal">
+    <label for="search-input" id="search-label">
+      <svg width='24' height='24' viewBox='0 0 24 24' fill='none'><path d='M21 21L15 15M17 10C17 13.866 13.866 17 10 17C6.13401 17 3 13.866 3 10C3 6.13401 6.13401 3 10 3C13.866 3 17 6.13401 17 10Z' stroke='#06b6d4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/></svg>
+    </label>
+    <input class="h-18 appearance-none mx-4 font-semibold flex-auto bg-transparent focus:outline-none" aria-autocomplete="list" aria-labelledby="search-label" id="search-input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Hľadať udalosť" maxlength="64" type="search">
+    <button class="flex-none rounded-lg border border-blue-500 text-blue-500 font-bold px-3 py-2 hover:bg-blue-100 text-xs" onclick="close_search()">Esc</button>
+  </div>
 
   <script id="template-event-item" type="x-tmpl-mustache">
     <section class="py-4 px-8 {{ background_color }} {{#is_active}}bg-orange-100{{/is_active}}" id="event-item-{{ id }}">


### PR DESCRIPTION
Na pc používa ctrl+f alebo F3 a seach bar funguje iba, keď je otvorený, svoj stav si však pamätá. Na mobile je search bar vo filter modale, funguje aj keď je modal zavretý, stav si neukladá asi by to iba zbytočne miatlo ľudí.

Celkovo hľadanie funguje na princípe `JSON.stringify(event).include(input)`. Na začiatok podľa mňa dostatočné, neskôr by sa dalo asi viac vyhrať.

depends on #98 (tailwind 2), implements a closes #107

![2021-04-02-004622_grim](https://user-images.githubusercontent.com/21214184/113361759-f1e44a80-934c-11eb-93ff-5a99b8b3901f.png)
![2021-04-02-004448_grim](https://user-images.githubusercontent.com/21214184/113361761-f27ce100-934c-11eb-9507-e41ae5f4c5c7.png)
